### PR TITLE
Add Docker option for running local development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,19 +3,9 @@
 
 # Packages
 .env
-/env
 messages.pot
-app/static/.webassets-cache/
 
 # Docker
 Dockerfile
 docker-compose.yml
 .dockerignore
-
-# Assets
-app/static/bower_components/*
-!app/static/bower_components/intl-tel-input
-app/static/bower_components/intl-tel-input/*
-!app/static/bower_components/intl-tel-input/build
-app/static/bower_components/intl-tel-input/build/*
-!app/static/bower_components/intl-tel-input/build/img

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+*.py[co]
+*.DS_*
+
+# Packages
+.env
+/env
+messages.pot
+app/static/.webassets-cache/
+
+# Docker
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+# Assets
+app/static/bower_components/*
+!app/static/bower_components/intl-tel-input
+app/static/bower_components/intl-tel-input/*
+!app/static/bower_components/intl-tel-input/build
+app/static/bower_components/intl-tel-input/build/*
+!app/static/bower_components/intl-tel-input/build/img

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,25 @@
 FROM python:alpine
 
+ARG PORT
+ARG MONGODB_URI
+ARG DEBUG
+
 ENV APP_DIR=/app
+ENV INTL_DIR=./app/static/bower_components/intl-tel-input/build/img
 
 WORKDIR $APP_DIR
 
 # Installing packages
 RUN apk update \
-    && apk add --no-cache --virtual .build_deps build-base python3-dev libffi-dev \
-    && apk add --no-cache nodejs \
-                          git \
-                          zlib-dev jpeg-dev
+    && apk add --no-cache --virtual .build_deps \
+    # Enable c-based pip dependencies
+    build-base python3-dev libffi-dev \
+    # Enable Pillow pip dependency
+    zlib-dev jpeg-dev \
+    # Enable npm
+    nodejs \
+    # Enable git
+    git
 
 RUN npm install -g bower
 
@@ -20,6 +30,9 @@ RUN bower install --allow-root --config.interactive=false -f bower.json
 # Install pip dependencies
 COPY ./requirements.txt .
 RUN pip install --user --no-cache-dir -r requirements.txt
+
+# Copy & build assets
+COPY $INTL_DIR $APP_DIR/$INTL_DIR
 RUN python manage.py assets build
 
 # Cleaning up everything

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:alpine
+
+ENV APP_DIR=/app
+
+WORKDIR $APP_DIR
+
+# Installing packages
+RUN apk update \
+    && apk add --no-cache --virtual .build_deps build-base python3-dev libffi-dev \
+    && apk add --no-cache nodejs \
+                          git \
+                          zlib-dev jpeg-dev
+
+RUN npm install -g bower
+
+# Install bower & dependencies
+COPY ./bower.json .
+RUN bower install --allow-root --config.interactive=false -f bower.json
+
+# Install pip dependencies
+COPY ./requirements.txt .
+RUN pip install --user --no-cache-dir -r requirements.txt
+RUN python manage.py assets build
+
+# Cleaning up everything
+RUN apk del .build_deps && rm -rf /var/cache/apk/*
+
+CMD ["gunicorn", "app:app"]

--- a/README.md
+++ b/README.md
@@ -8,50 +8,72 @@
 This is the repository of [Forum Organisation](https://www.forumorg.org)'s official website.
 
 ## Getting Started
-
 These instructions will get help get your own copy of the project running on your local machine for development and testing purposes.
 
-### Requirements
+#### Install
+In order to run this project, you will need [Docker CE](https://docs.docker.com/install/) installed in your machine.
 
-To get your development environment running, you need:
-
-- [python 3](https://www.python.org/downloads/)
-- [bower](https://bower.io/#install-bower)
-- [mongodb](https://www.mongodb.com/download-center#community)
-
-### Install
-
-To install the necessary dependencies:
+To check if it's been installed correctly, run `docker --version && docker-compose --version` and see if it returns something like this:
 
 ```sh
-git clone https://github.com/ForumOrganisation/forumorg.git
-cd forumorg && pip install -r requirements.txt
-bower install
-```
-
-### Configuration
-To start the project, you need to provide the following environment variables:
-
-```sh
-export MONGODB_URI="mongodb://host:port/dbname" # Required: local running mongodb instance
-export BUCKET_NAME="bucket_name" # Required: S3 bucket name
-export DEBUG=True # Optional: Nice for debugging
-export SENDGRID_API_KEY="sendgrid_key" # Optional: for emailing events
+Docker version 17.09.0-ce, build afdb6d4
+docker-compose version 1.16.1, build 6d1ac21
 ```
 
 ### Run
+First of all, you need to checkout the project:
 ```sh
-python runserver.py
+git clone https://github.com/ForumOrganisation/forumorg.git
 ```
 
-## Deploying
-We use Heroku for Cloud hosting and Continuous Integration, using this continuous delivery workflow:
+Then you need to fill the following environment variables in a `.env` file at the root of the project:
 
-- A developer creates a pull request to make a change to the codebase.
-- Heroku automatically creates a review app for the pull request, allowing developers to test the change.
-- When the change is ready, it’s merged into the codebase’s master branch.
-- The master branch is automatically deployed to [staging](https://forumorg-staging.herokuapp.com) for further testing.
-- When it’s ready, the staging app is promoted to [production](https://www.forumorg.org), where the change is available to end users of the app.
+```sh
+BUCKET_NAME="bucket_name" # Required: S3 bucket name
+SENDGRID_API_KEY="sendgrid_key" # Optional: for emailing events
+RECAPTCHA_SECRET_KEY="recaptcha_key" # Optional: for recaptcha forms
+```
+
+Finally, run `docker-compose up -d` and your app should be deployed at http://localhost:5000
+
+### Develop
+* Change some files, make some code then refresh the page: you should see your changes applied!
+* Log your app behaviour by inspecting it with `docker-compose logs web`
+* Commit at the end of your work and follow the deploy steps.
+
+### Deploy
+We use Heroku for Cloud hosting and Continuous Integration.
+
+#### Heroku CLI
+The Heroku Command Line Interface (CLI) makes it easy to create and manage your Heroku apps directly from the terminal.
+It’s an essential part of using Heroku. Install it by following [these guidelines](https://devcenter.heroku.com/articles/heroku-cli#download-and-install).
+
+Heroku can be set to recognize your working app directory as the deployed heroku app(s), by adding the following git remotes:
+
+```sh
+git remote add production https://git.heroku.com/forumorg-prod.git
+git remote add staging https://git.heroku.com/forumorg-staging.git
+```
+
+#### Deployment process
+On ```any pull request``` ([see how](https://help.github.com/articles/creating-a-pull-request/)):
+- A temporary review app is created, which can be live tested.
+- If everything is working OK, the PR can be merged into `master`.
+
+On ```push to master```:
+- A build is triggered on our [staging app](https://forumorg-staging.herokuapp.com) (useful for testing in a production-like environment).
+
+On ```heroku pipelines:promote -r staging --to production```:
+- The staging app is instantly deployed to [production](https://www.forumorg.org).
+
+## Running scripts
+Some tasks on the platform requires one-off execution of scripts, like batch updates performed in database.
+
+You can execute a script by adding it to **manage.py** as a python function, then run:
+
+```sh
+heroku local:run python manage.py my_script
+```
 
 ## Localization
 The app is localized using:
@@ -63,7 +85,9 @@ You can get familiar with the process [by following this tutorial](https://phras
 
 ## Contributions
 
-Contributions are very welcome! If you find a bug or some improvements, feel free to raise an issue and send a PR! Please see the [CONTRIBUTING](CONTRIBUTING.md) file for more information on how to contribute.
+Contributions are very welcome! If you find a bug or some improvements, feel free to raise an issue and send a PR!
+
+Please see the [CONTRIBUTING](CONTRIBUTING.md) file for more information on how to contribute.
 
 ## Authors
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,7 +9,6 @@ from flask_assets import Environment
 from flask_babelex import Babel, Domain
 from flask_bcrypt import Bcrypt
 from flask_cdn import CDN
-from flask_debugtoolbar import DebugToolbarExtension
 from flask_login import LoginManager
 from flask_qrcode import QRcode
 from flask_sslify import SSLify
@@ -31,12 +30,11 @@ app.debug = bool(os.environ.get('DEBUG', False))
 app.config['SECRET_KEY'] = os.environ.get('FLASK_SECRET_KEY', 'my_debug_key')
 app.config['SECURITY_PASSWORD_SALT'] = os.environ.get('FLASK_PASSWORD_SALT', 'my_debug_salt')
 app.config['TOKEN_EXPIRATION'] = int(os.environ.get('TOKEN_EXPIRATION', 7200))
-app.config['PASSWORD_TOKEN_EXPIRATION'] = int(os.environ.get('PASSWORD_TOKEN_EXPIRATION',600))#needs to be shorter for security reasons
+app.config['PASSWORD_TOKEN_EXPIRATION'] = int(os.environ.get('PASSWORD_TOKEN_EXPIRATION', 600)) #needs to be shorter for security reasons
 app.config['CDN_DOMAIN'] = os.environ.get('CLOUDFRONT_DOMAIN')
 app.config['CDN_DEBUG'] = app.debug
 app.config['CDN_HTTPS'] = True
 app.config['TEMPLATES_AUTO_RELOAD'] = True
-app.config['DEBUG_TB_INTERCEPT_REDIRECTS'] = False
 app.config['BABEL_DEFAULT_LOCALE'] = 'fr'
 app.jinja_env.add_extension('jinja2_time.TimeExtension')
 
@@ -56,10 +54,6 @@ qrcode.init_app(app)
 domain = Domain(dirname='translations')
 babel = Babel(default_domain=domain)
 babel.init_app(app)
-
-# Toolbar
-toolbar = DebugToolbarExtension()
-toolbar.init_app(app)
 
 # Flask-Assets
 from .assets import bundles

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '2'
+
+services:
+  web:
+    build:
+      context: .
+      args:
+        - http_proxy=http://proxy.priv.atos.fr:3128/
+        - https_proxy=http://proxy.priv.atos.fr:3128/
+        - no_proxy=localhost,127.0.0.1,kazan.priv.atos.fr,*.priv.atos.fr
+    env_file: .env
+    environment:
+      - PORT=5000
+      - MONGODB_URI=mongodb://localhost:27017/local
+      - DEBUG=True
+    ports:
+      - "5000:5000"
+    depends_on:
+      - db
+    volumes:
+      - .:./app
+
+  db:
+    image: mongo:3.0
+    ports:
+      - "27017:27017"
+
+networks:
+  default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,10 @@ services:
     build:
       context: .
       args:
-        - PORT=5000
         - MONGODB_URI=mongodb://localhost:27017/local
+    environment:
+        - MONGODB_URI=mongodb://localhost:27017/local
+        - PORT=5000
         - DEBUG=True
     env_file: .env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,20 +5,16 @@ services:
     build:
       context: .
       args:
-        - http_proxy=http://proxy.priv.atos.fr:3128/
-        - https_proxy=http://proxy.priv.atos.fr:3128/
-        - no_proxy=localhost,127.0.0.1,kazan.priv.atos.fr,*.priv.atos.fr
+        - PORT=5000
+        - MONGODB_URI=mongodb://localhost:27017/local
+        - DEBUG=True
     env_file: .env
-    environment:
-      - PORT=5000
-      - MONGODB_URI=mongodb://localhost:27017/local
-      - DEBUG=True
     ports:
       - "5000:5000"
     depends_on:
       - db
     volumes:
-      - .:./app
+      - .:/app
 
   db:
     image: mongo:3.0

--- a/manage.py
+++ b/manage.py
@@ -6,9 +6,6 @@ from flask_assets import ManageAssets
 from flask_script import Manager
 from pymongo import MongoClient
 
-client = MongoClient(host=os.environ.get('MONGODB_URI'))
-db = client.get_default_database()
-
 
 manager = Manager(app)
 manager.add_command('assets', ManageAssets())

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,8 @@ Flask-Babel==0.11.2
 Flask-BabelEx==0.9.3
 Flask-Bcrypt==0.7.1
 Flask-CDN==1.5.3
-Flask-DebugToolbar==0.10.1
-Flask-Login==0.4.1
-Flask-QRcode==1.1.2
+Flask-Login==0.4.0
+Flask-QRcode==1.0.1
 Flask-Script==2.0.6
 Flask-SSLify==0.1.5
 gunicorn==19.7.1


### PR DESCRIPTION
No more messing around with pip installs, mongo files and bower stuff.

With docker-compose, setting up a local dev environment is as easy as running `docker-compose up -d` (checkout README.md for more details)